### PR TITLE
Fix missing strings import when generating without `-lower` flag

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -249,6 +249,9 @@ import (
 	"fmt"
 
 	"database/sql/driver"
+	{{- if .LowerCase | not }}
+	"strings"
+	{{- end}}
 )
 
 // {{.Type | title}} is the exported type for the enum


### PR DESCRIPTION
This pull request fixes a missing `strings` package import in the generated code when running the generation without the `-lower` flag.