### PR TITLE
Add support to get the enum value by the constant int value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.prof
 .idea
+mise.toml

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ go generate ./...
 - `-type` (required): the name of the type to generate enum for (must be private)
 - `-path`: output directory path (default: same as source)
 - `-lower`: use lowercase for marshaled/unmarshaled values
-- `-getter`: Additionally generates a getter function for enum values. The `-getter` flag requires enum values to be unique to prevent undefined behavior.
+- `-getter`: enables the generation of an additional function, `Get{{Type}}ByID`, which attempts to find the corresponding enum element by its underlying integer ID. The `-getter` flag requires enum elements to have unique IDs to prevent undefined behavior.
 - `-version`: print version information
 - `-help`: show usage information
 
@@ -105,7 +105,7 @@ The generator creates a new type with the following features:
 - All possible names slice (`StatusNames`)
 - Public constants for each value (`StatusActive`, `StatusInactive`, etc.)
 
-Additionally, if the `-getter` flag is set, a getter function (`GetStatus`) will be generated. This function allows retrieving an enum value by its raw integer value.
+Additionally, if the `-getter` flag is set, a getter function (`GetStatusByID`) will be generated. This function allows retrieving an enum element using its raw integer ID.
 
 ### Case Sensitivity
 
@@ -118,6 +118,13 @@ StatusActive.String() // returns "Active"
 // with -lower flag
 StatusActive.String() // returns "active"
 ```
+
+### Getter Generation
+
+The `-getter` flag enables the generation of an additional function, `Get{{Type}}ByID`, which attempts to find the corresponding enum element by its underlying integer ID. If no matching element is found, an error is returned.
+
+> **Note:**
+> The `-getter` flag requires all IDs in the generated enum to be unique to prevent undefined behavior. If duplicate IDs are found, generation will fail with an error specifying which elements share the same ID.
 
 ### Error Handling
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ go generate ./...
 - `-type` (required): the name of the type to generate enum for (must be private)
 - `-path`: output directory path (default: same as source)
 - `-lower`: use lowercase for marshaled/unmarshaled values
+- `-getter`: Additionally generates a getter function for enum values. The `-getter` flag requires enum values to be unique to prevent undefined behavior.
 - `-version`: print version information
 - `-help`: show usage information
 
@@ -100,10 +101,11 @@ The generator creates a new type with the following features:
 - Text marshaling (implements `encoding.TextMarshaler` and `encoding.TextUnmarshaler`)
 - Parse function with error handling (`ParseStatus`)
 - Must-style parse function that panics on error (`MustStatus`)
-- Get function with error handling (`GetStatus`)
 - All possible values slice (`StatusValues`)
 - All possible names slice (`StatusNames`)
 - Public constants for each value (`StatusActive`, `StatusInactive`, etc.)
+
+Additionally, if the `-getter` flag is set, a getter function (`GetStatus`) will be generated. This function allows retrieving an enum value by its raw integer value.
 
 ### Case Sensitivity
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ The generator creates a new type with the following features:
 - Text marshaling (implements `encoding.TextMarshaler` and `encoding.TextUnmarshaler`)
 - Parse function with error handling (`ParseStatus`)
 - Must-style parse function that panics on error (`MustStatus`)
+- Get function with error handling (`GetStatus`)
 - All possible values slice (`StatusValues`)
 - All possible names slice (`StatusNames`)
 - Public constants for each value (`StatusActive`, `StatusInactive`, etc.)

--- a/_examples/status/job_status_enum.go
+++ b/_examples/status/job_status_enum.go
@@ -84,8 +84,8 @@ func MustJobStatus(v string) JobStatus {
 	return r
 }
 
-// GetJobStatus gets the correspondent jobStatus enum value
-func GetJobStatus(v int) (JobStatus, error) {
+// GetJobStatusByID gets the correspondent jobStatus enum value by its ID (raw integer value)
+func GetJobStatusByID(v int) (JobStatus, error) {
 	switch v {
 	case 1:
 		return JobStatusActive, nil

--- a/_examples/status/job_status_enum.go
+++ b/_examples/status/job_status_enum.go
@@ -84,6 +84,21 @@ func MustJobStatus(v string) JobStatus {
 	return r
 }
 
+// GetJobStatus gets the correspondent jobStatus enum value
+func GetJobStatus(v int) (JobStatus, error) {
+	switch v {
+	case 1:
+		return JobStatusActive, nil
+	case 3:
+		return JobStatusBlocked, nil
+	case 2:
+		return JobStatusInactive, nil
+	case 0:
+		return JobStatusUnknown, nil
+	}
+	return JobStatus{}, fmt.Errorf("invalid jobStatus value: %d", v)
+}
+
 // Public constants for jobStatus values
 var (
 	JobStatusActive   = JobStatus{name: "active", value: 1}

--- a/_examples/status/status.go
+++ b/_examples/status/status.go
@@ -1,7 +1,7 @@
 package status
 
 //go:generate go run ../../main.go -type status -lower
-//go:generate go run ../../main.go -type jobStatus -lower
+//go:generate go run ../../main.go -type jobStatus -lower -getter
 
 type status uint8
 

--- a/_examples/status/status_enum.go
+++ b/_examples/status/status_enum.go
@@ -84,21 +84,6 @@ func MustStatus(v string) Status {
 	return r
 }
 
-// GetStatus gets the correspondent status enum value
-func GetStatus(v int) (Status, error) {
-	switch v {
-	case 1:
-		return StatusActive, nil
-	case 3:
-		return StatusBlocked, nil
-	case 2:
-		return StatusInactive, nil
-	case 0:
-		return StatusUnknown, nil
-	}
-	return Status{}, fmt.Errorf("invalid status value: %d", v)
-}
-
 // Public constants for status values
 var (
 	StatusActive   = Status{name: "active", value: 1}

--- a/_examples/status/status_enum.go
+++ b/_examples/status/status_enum.go
@@ -84,6 +84,21 @@ func MustStatus(v string) Status {
 	return r
 }
 
+// GetStatus gets the correspondent status enum value
+func GetStatus(v int) (Status, error) {
+	switch v {
+	case 1:
+		return StatusActive, nil
+	case 3:
+		return StatusBlocked, nil
+	case 2:
+		return StatusInactive, nil
+	case 0:
+		return StatusUnknown, nil
+	}
+	return Status{}, fmt.Errorf("invalid status value: %d", v)
+}
+
 // Public constants for status values
 var (
 	StatusActive   = Status{name: "active", value: 1}

--- a/internal/generator/enum.go.tmpl
+++ b/internal/generator/enum.go.tmpl
@@ -90,8 +90,8 @@ func Must{{.Type | title}}(v string) {{.Type | title}} {
 }
 
 {{if .GenerateGetter -}}
-// Get{{.Type | title}} gets the correspondent {{.Type}} enum value
-func Get{{.Type | title}}(v int) ({{.Type | title}}, error) {
+// Get{{.Type | title}}ByID gets the correspondent {{.Type}} enum value by its ID (raw integer value)
+func Get{{.Type | title}}ByID(v int) ({{.Type | title}}, error) {
 	switch v {
 	{{range .Values -}}
 	case {{.Index}}:

--- a/internal/generator/enum.go.tmpl
+++ b/internal/generator/enum.go.tmpl
@@ -89,6 +89,17 @@ func Must{{.Type | title}}(v string) {{.Type | title}} {
 	return r
 }
 
+// Get{{.Type | title}} gets the correspondent {{.Type}} enum value
+func Get{{.Type | title}}(v int) ({{.Type | title}}, error) {
+	switch v {
+	{{range .Values -}}
+	case {{.Index}}:
+		return {{.PublicName}}, nil
+	{{end -}}
+	}
+	return {{.Type | title}}{}, fmt.Errorf("invalid {{.Type}} value: %d", v)
+}
+
 // Public constants for {{.Type}} values
 var (
 {{range .Values -}}

--- a/internal/generator/enum.go.tmpl
+++ b/internal/generator/enum.go.tmpl
@@ -89,6 +89,7 @@ func Must{{.Type | title}}(v string) {{.Type | title}} {
 	return r
 }
 
+{{if .GenerateGetter -}}
 // Get{{.Type | title}} gets the correspondent {{.Type}} enum value
 func Get{{.Type | title}}(v int) ({{.Type | title}}, error) {
 	switch v {
@@ -99,6 +100,7 @@ func Get{{.Type | title}}(v int) ({{.Type | title}}, error) {
 	}
 	return {{.Type | title}}{}, fmt.Errorf("invalid {{.Type}} value: %d", v)
 }
+{{end -}}
 
 // Public constants for {{.Type}} values
 var (

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -217,6 +217,80 @@ func TestGenerator(t *testing.T) {
 		assert.Contains(t, string(content), "value: 30") // should have actual value 30, not 2
 	})
 
+	t.Run("generate getter", func(t *testing.T) {
+		// create temp dir for output
+		tmpDir := t.TempDir()
+
+		gen, err := New("jobStatus", tmpDir)
+		require.NoError(t, err)
+		gen.SetGenerateGetter(true)
+
+		// parse testdata
+		err = gen.Parse("testdata")
+		require.NoError(t, err)
+
+		// generate
+		err = gen.Generate()
+		require.NoError(t, err)
+
+		// verify file was created
+		content, err := os.ReadFile(filepath.Join(tmpDir, "job_status_enum.go"))
+		require.NoError(t, err)
+
+		// check content
+		assert.Contains(t, string(content), "func GetJobStatus(v int) (JobStatus, error)")
+		assert.Contains(t, string(content), "case 0:\n\t\treturn JobStatusUnknown, nil")
+		assert.Contains(t, string(content), "case 1:\n\t\treturn JobStatusActive, nil")
+		assert.Contains(t, string(content), "case 2:\n\t\treturn JobStatusInactive, nil")
+		assert.Contains(t, string(content), "case 3:\n\t\treturn JobStatusBlocked, nil")
+	})
+
+	t.Run("generate getter explicit values", func(t *testing.T) {
+		// create temp dir for output
+		tmpDir := t.TempDir()
+
+		gen, err := New("explicitValues", tmpDir)
+		require.NoError(t, err)
+		gen.SetGenerateGetter(true)
+
+		// parse testdata
+		err = gen.Parse("testdata")
+		require.NoError(t, err)
+
+		// generate
+		err = gen.Generate()
+		require.NoError(t, err)
+
+		// verify file was created
+		content, err := os.ReadFile(filepath.Join(tmpDir, "explicit_values_enum.go"))
+		require.NoError(t, err)
+
+		// check content
+		assert.Contains(t, string(content), "func GetExplicitValues(v int) (ExplicitValues, error)")
+		assert.Contains(t, string(content), "case 10:\n\t\treturn ExplicitValuesFirst, nil")
+		assert.Contains(t, string(content), "case 20:\n\t\treturn ExplicitValuesSecond, nil")
+		assert.Contains(t, string(content), "case 30:\n\t\treturn ExplicitValuesThird, nil")
+	})
+
+	t.Run("generate getter repeated values", func(t *testing.T) {
+		// create temp dir for output
+		tmpDir := t.TempDir()
+
+		gen, err := New("repeatValues", tmpDir)
+		require.NoError(t, err)
+		gen.SetGenerateGetter(true)
+
+		// parse testdata
+		err = gen.Parse("testdata")
+		require.NoError(t, err)
+
+		// generate
+		err = gen.Generate()
+		require.Error(t, err, "should fail with repeated values")
+		assert.Contains(t, err.Error(), "multiple names for value 10: ")
+		assert.Contains(t, err.Error(), "multiple names for value 20: ")
+	})
+
 	t.Run("invalid package", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		err := os.WriteFile(filepath.Join(tmpDir, "invalid.go"), []byte(`invalid go file`), 0o600)

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -238,7 +238,7 @@ func TestGenerator(t *testing.T) {
 		require.NoError(t, err)
 
 		// check content
-		assert.Contains(t, string(content), "func GetJobStatus(v int) (JobStatus, error)")
+		assert.Contains(t, string(content), "func GetJobStatusByID(v int) (JobStatus, error)")
 		assert.Contains(t, string(content), "case 0:\n\t\treturn JobStatusUnknown, nil")
 		assert.Contains(t, string(content), "case 1:\n\t\treturn JobStatusActive, nil")
 		assert.Contains(t, string(content), "case 2:\n\t\treturn JobStatusInactive, nil")
@@ -266,7 +266,7 @@ func TestGenerator(t *testing.T) {
 		require.NoError(t, err)
 
 		// check content
-		assert.Contains(t, string(content), "func GetExplicitValues(v int) (ExplicitValues, error)")
+		assert.Contains(t, string(content), "func GetExplicitValuesByID(v int) (ExplicitValues, error)")
 		assert.Contains(t, string(content), "case 10:\n\t\treturn ExplicitValuesFirst, nil")
 		assert.Contains(t, string(content), "case 20:\n\t\treturn ExplicitValuesSecond, nil")
 		assert.Contains(t, string(content), "case 30:\n\t\treturn ExplicitValuesThird, nil")

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ func main() {
 	typeFlag := flag.String("type", "", "type name (must be lowercase)")
 	pathFlag := flag.String("path", "", "output directory path (default: same as source)")
 	lowerFlag := flag.Bool("lower", false, "use lower case for marshaled/unmarshaled values")
+	getterFlag := flag.Bool("getter", false, "generate getter methods for enum values")
 	helpFlag := flag.Bool("help", false, "show usage")
 	versionFlag := flag.Bool("version", false, "print version")
 	flag.Parse()
@@ -49,6 +50,7 @@ func main() {
 	}
 
 	gen.SetLowerCase(*lowerFlag)
+	gen.SetGenerateGetter(*getterFlag)
 
 	if err := gen.Parse("."); err != nil {
 		fmt.Printf("%v\n", err)


### PR DESCRIPTION
In my use case, the code may receive enum values in either integer or string form, depending on the data source (e.g., HTTP endpoints receive the string form, while gRPC uses integers). To support this, I need a way to easily validate whether an integer value corresponds to a valid enum.

This pull request adds the method:

```go
Get{{Type}}(v int) ({{Type}}, error)
```

Which is a "reverse" method for `Parse{{Type}}`

> **Note:**
> I’m not sure what to do if multiple enum values correspond to the same integer value. This would result in some kind of undefined behavior. Maybe it would be better to make the Get method generation optional (only if a correspondent flag is set). Alternativelly it's possible to implement some kind of `MultiGet` method for such type of enums