### PR TITLE
Add support for explicit enum values instead of assuming sequential iota values

### DIFF
--- a/_examples/status/job_status_test.go
+++ b/_examples/status/job_status_test.go
@@ -112,5 +112,5 @@ func TestJobStatus(t *testing.T) {
 func ExampleJobStatus() {
 	s := JobStatusActive
 	fmt.Println(s.String())
-	// Output: active
+	// output: active
 }

--- a/_examples/status/status_test.go
+++ b/_examples/status/status_test.go
@@ -112,5 +112,5 @@ func TestStatus(t *testing.T) {
 func ExampleStatus() {
 	s := StatusActive
 	fmt.Println(s.String())
-	// Output: active
+	// output: active
 }

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -191,6 +191,32 @@ func TestGenerator(t *testing.T) {
 		assert.Error(t, err)
 	})
 
+	t.Run("explicit values", func(t *testing.T) {
+		// create temp dir for output
+		tmpDir := t.TempDir()
+
+		gen, err := New("explicitValues", tmpDir)
+		require.NoError(t, err)
+
+		// parse testdata
+		err = gen.Parse("testdata")
+		require.NoError(t, err)
+
+		// generate
+		err = gen.Generate()
+		require.NoError(t, err)
+
+		// verify file was created
+		content, err := os.ReadFile(filepath.Join(tmpDir, "explicit_values_enum.go"))
+		require.NoError(t, err)
+
+		// check content
+		assert.Contains(t, string(content), "type ExplicitValues struct")
+		assert.Contains(t, string(content), "value: 10") // Should have actual value 10, not 0
+		assert.Contains(t, string(content), "value: 20") // Should have actual value 20, not 1
+		assert.Contains(t, string(content), "value: 30") // Should have actual value 30, not 2
+	})
+
 	t.Run("invalid package", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		err := os.WriteFile(filepath.Join(tmpDir, "invalid.go"), []byte(`invalid go file`), 0o600)

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -212,9 +212,9 @@ func TestGenerator(t *testing.T) {
 
 		// check content
 		assert.Contains(t, string(content), "type ExplicitValues struct")
-		assert.Contains(t, string(content), "value: 10") // Should have actual value 10, not 0
-		assert.Contains(t, string(content), "value: 20") // Should have actual value 20, not 1
-		assert.Contains(t, string(content), "value: 30") // Should have actual value 30, not 2
+		assert.Contains(t, string(content), "value: 10") // should have actual value 10, not 0
+		assert.Contains(t, string(content), "value: 20") // should have actual value 20, not 1
+		assert.Contains(t, string(content), "value: 30") // should have actual value 30, not 2
 	})
 
 	t.Run("invalid package", func(t *testing.T) {
@@ -262,6 +262,21 @@ func TestGeneratorValues(t *testing.T) {
 	assert.Equal(t, 1, gen.values["statusActive"], "active should be 1")
 	assert.Equal(t, 2, gen.values["statusInactive"], "inactive should be 2")
 	assert.Equal(t, 3, gen.values["statusBlocked"], "blocked should be 3")
+}
+
+func TestRepeatValues(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	gen, err := New("repeatValues", tmpDir)
+	require.NoError(t, err)
+
+	err = gen.Parse("testdata")
+	require.NoError(t, err)
+
+	assert.Equal(t, 10, gen.values["repeatValuesFirst"], "First should be 10")
+	assert.Equal(t, 10, gen.values["repeatValuesSecond"], "Second should repeat the value 10") // currently fails
+	assert.Equal(t, 20, gen.values["repeatValuesThird"], "Third should be 20")
+	assert.Equal(t, 20, gen.values["repeatValuesFourth"], "Fourth should repeat the value 20") // currently fails
 }
 
 func TestGeneratorSubdir(t *testing.T) {
@@ -342,11 +357,11 @@ func TestGeneratorLowerCase(t *testing.T) {
 
 func TestGeneratorEdgeCases(t *testing.T) {
 	t.Run("invalid template", func(t *testing.T) {
-		// Create a generator with a broken template that will fail to execute
+		// create a generator with a broken template that will fail to execute
 		gen, err := New("status", "")
 		require.NoError(t, err)
 
-		// Override template with invalid one
+		// override template with invalid one
 		origTmpl := enumTemplate
 		defer func() { enumTemplate = origTmpl }()
 		enumTemplate = template.Must(template.New("broken").Parse("{{.Unknown}}")) // will fail on execution
@@ -363,7 +378,7 @@ func TestGeneratorEdgeCases(t *testing.T) {
 		gen, err := New("status", "")
 		require.NoError(t, err)
 
-		// Override template to generate invalid Go code
+		// override template to generate invalid Go code
 		origTmpl := enumTemplate
 		defer func() { enumTemplate = origTmpl }()
 		enumTemplate = template.Must(template.New("invalid").Parse("invalid go code"))

--- a/internal/generator/testdata/explicit_values.go
+++ b/internal/generator/testdata/explicit_values.go
@@ -1,0 +1,9 @@
+package testdata
+
+type explicitValues uint8
+
+const (
+	explicitValuesFirst  explicitValues = 10
+	explicitValuesSecond explicitValues = 20
+	explicitValuesThird  explicitValues = 30
+)

--- a/internal/generator/testdata/repeat_values.go
+++ b/internal/generator/testdata/repeat_values.go
@@ -1,0 +1,10 @@
+package testdata
+
+type repeatValues uint8
+
+const (
+	repeatValuesFirst  repeatValues = 10
+	repeatValuesSecond repeatValues     // This should repeat the value 10
+	repeatValuesThird  repeatValues = 20
+	repeatValuesFourth repeatValues     // This should repeat the value 20
+)

--- a/main_test.go
+++ b/main_test.go
@@ -20,7 +20,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegration(t *testing.T) {
-	// Reset flags between runs to avoid "flag redefined" error
+	// reset flags between runs to avoid "flag redefined" error
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 
 	t.Run("generate enum", func(t *testing.T) {
@@ -69,7 +69,7 @@ const (
 	})
 
 	t.Run("lower case", func(t *testing.T) {
-		// Reset flags for this run
+		// reset flags for this run
 		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 
 		origArgs := os.Args
@@ -108,7 +108,7 @@ const (
 	})
 
 	t.Run("version", func(t *testing.T) {
-		// Reset flags for this run
+		// reset flags for this run
 		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 
 		origArgs := os.Args
@@ -123,7 +123,7 @@ const (
 	})
 
 	t.Run("help", func(t *testing.T) {
-		// Reset flags for this run
+		// reset flags for this run
 		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 
 		origArgs := os.Args
@@ -138,7 +138,7 @@ const (
 	})
 
 	t.Run("missing type", func(t *testing.T) {
-		// Reset flags for this run
+		// reset flags for this run
 		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 
 		origArgs := os.Args
@@ -153,7 +153,7 @@ const (
 	})
 
 	t.Run("uppercase type", func(t *testing.T) {
-		// Reset flags for this run
+		// reset flags for this run
 		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 
 		origArgs := os.Args


### PR DESCRIPTION
This PR fixes an issue where the enum generator was ignoring explicitly defined enum values and always using sequential values (0, 1, 2, etc.) as if all enum values were defined using iota.

Before this change, if a user defined enum values like:
```go
const (
    statusTypeUnknown statusType = 0
    statusTypeActive  statusType = 10
    statusTypePending statusType = 20
    statusTypeDone    statusType = 30
)
```

The generator would ignore these explicit values and use (0, 1, 2, 3) instead.

Changes:
- Enhanced the `parseFile` method to properly extract explicit numeric values from constant definitions
- Added support for mixed cases (some values using iota, others with explicit values)
- Added test case for explicit enum values

This improvement allows users to define their enum values with specific numeric values when needed, which is important for:
- Backward compatibility in APIs
- Integration with external systems that expect specific values
- Supporting bit flags and other numeric patterns
- Maintaining semantic meaning for numeric values 