### PR TITLE
Add Go 1.23 iterator support and migrate to golangci-lint v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,9 @@ jobs:
         run: go test -timeout=60s -race
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: latest
+          version: v2.0.2
           skip-pkg-cache: true
 
       - name: install goveralls

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,78 +1,81 @@
-linters-settings:
-  govet:
-    shadow: true
-  gocyclo:
-    min-complexity: 15
-  maligned:
-    suggest-new: true
-  goconst:
-    min-len: 2
-    min-occurrences: 2
-  misspell:
-    locale: US
-  lll:
-    line-length: 140
-  gocritic:
-    enabled-tags:
-      - performance
-      - style
-      - experimental
-    disabled-checks:
-      - wrapperFunc
-
+version: "2"
+run:
+  concurrency: 4
 linters:
+  default: none
   enable:
-    - staticcheck
-    - revive
-    - govet
-    - unconvert
-    - gosec
-    - unparam
-    - typecheck
-    - ineffassign
-    - stylecheck
-    - gochecknoinits
-    - copyloopvar
-    - gocritic
-    - nakedret
-    - gosimple
-    - prealloc
-    - unused
     - contextcheck
     - copyloopvar
     - decorder
     - errorlint
     - exptostd
-    - gofmt
-    - goimports
+    - gochecknoinits
+    - gocritic
+    - gosec
+    - govet
+    - ineffassign
     - intrange
+    - nakedret
     - nilerr
+    - prealloc
     - predeclared
+    - revive
+    - staticcheck
     - testifylint
     - thelper
-  fast: false
-  disable-all: true
-
-
-run:
-  concurrency: 4
-
-issues:
-  exclude-rules:
-    - text: "G114: Use of net/http serve function that has no support for setting timeouts"
-      linters:
-        - gosec
-    - linters:
-        - unparam
-        - revive
-      path: _test\.go$
-      text: "unused-parameter"
-    - linters:
-        - prealloc
-      path: _test\.go$
-      text: "Consider pre-allocating"
-    - linters:
-        - gosec
-        - intrange
-      path: _test\.go$
-  exclude-use-default: false
+    - unconvert
+    - unparam
+    - unused
+  settings:
+    goconst:
+      min-len: 2
+      min-occurrences: 2
+    gocritic:
+      disabled-checks:
+        - wrapperFunc
+      enabled-tags:
+        - performance
+        - style
+        - experimental
+    gocyclo:
+      min-complexity: 15
+    govet:
+      enable:
+        - shadow
+    lll:
+      line-length: 140
+    misspell:
+      locale: US
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - gosec
+        text: 'G114: Use of net/http serve function that has no support for setting timeouts'
+      - linters:
+          - revive
+          - unparam
+        path: _test\.go$
+        text: unused-parameter
+      - linters:
+          - prealloc
+        path: _test\.go$
+        text: Consider pre-allocating
+      - linters:
+          - gosec
+          - intrange
+        path: _test\.go$
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - Easy value enumeration with Values() and Names() functions
 - Generated code is fully tested and documented
 - No external runtime dependencies
+- Supports Go 1.23's range-over-func iteration
 
 ## Quick Start
 
@@ -51,6 +52,11 @@ type Data struct {
 d := Data{Status: StatusActive}
 b, _ := json.Marshal(d)
 fmt.Println(string(b)) // prints: {"status":"active"}
+
+// iterate over all values using Go 1.23 range-over-func
+for status := range StatusIter() {
+    fmt.Println(status) // prints each status in turn
+}
 ```
 
 ## Installation
@@ -103,6 +109,7 @@ The generator creates a new type with the following features:
 - Must-style parse function that panics on error (`MustStatus`)
 - All possible values slice (`StatusValues`)
 - All possible names slice (`StatusNames`)
+- Go 1.23 iterator support (`StatusIter()`) for range-over-func syntax
 - Public constants for each value (`StatusActive`, `StatusInactive`, etc.)
 
 Additionally, if the `-getter` flag is set, a getter function (`GetStatusByID`) will be generated. This function allows retrieving an enum element using its raw integer ID.

--- a/_examples/status/job_status_enum.go
+++ b/_examples/status/job_status_enum.go
@@ -126,3 +126,14 @@ func JobStatusNames() []string {
 		"unknown",
 	}
 }
+
+// JobStatusIter returns an iterator over all enum values
+func JobStatusIter() func(yield func(JobStatus) bool) {
+	return func(yield func(JobStatus) bool) {
+		for _, v := range JobStatusValues() {
+			if !yield(v) {
+				break
+			}
+		}
+	}
+}

--- a/_examples/status/job_status_test.go
+++ b/_examples/status/job_status_test.go
@@ -141,7 +141,7 @@ func ExampleJobStatusIter() {
 	for js := range JobStatusIter() {
 		allStatuses = append(allStatuses, js)
 	}
-	fmt.Println("All job statuses:", len(allStatuses))
+	fmt.Println("all job statuses:", len(allStatuses))
 
 	// early termination example
 	var firstTwo []JobStatus
@@ -153,7 +153,7 @@ func ExampleJobStatusIter() {
 			break
 		}
 	}
-	fmt.Println("First two job statuses:", firstTwo[0], firstTwo[1])
+	fmt.Println("first two job statuses:", firstTwo[0], firstTwo[1])
 	// output:
 	// all job statuses: 4
 	// first two job statuses: active blocked

--- a/_examples/status/status_enum.go
+++ b/_examples/status/status_enum.go
@@ -111,3 +111,14 @@ func StatusNames() []string {
 		"unknown",
 	}
 }
+
+// StatusIter returns an iterator over all enum values
+func StatusIter() func(yield func(Status) bool) {
+	return func(yield func(Status) bool) {
+		for _, v := range StatusValues() {
+			if !yield(v) {
+				break
+			}
+		}
+	}
+}

--- a/_examples/status/status_test.go
+++ b/_examples/status/status_test.go
@@ -100,6 +100,26 @@ func TestStatus(t *testing.T) {
 		assert.Equal(t, StatusValues()[0], s)
 	})
 
+	t.Run("iterator", func(t *testing.T) {
+		var collected []Status
+		StatusIter()(func(s Status) bool {
+			collected = append(collected, s)
+			return true
+		})
+
+		assert.Equal(t, StatusValues(), collected)
+
+		collected = nil
+		count := 0
+		StatusIter()(func(s Status) bool {
+			collected = append(collected, s)
+			count++
+			return count < 2 // stop after collecting 2 items
+		})
+
+		assert.Equal(t, StatusValues()[:2], collected)
+	})
+
 	t.Run("invalid", func(t *testing.T) {
 		var d struct {
 			Status Status `json:"status"`
@@ -113,4 +133,28 @@ func ExampleStatus() {
 	s := StatusActive
 	fmt.Println(s.String())
 	// output: active
+}
+
+func ExampleStatusIter() {
+	// using Go 1.23 range-over-func feature
+	var allStatuses []Status
+	for s := range StatusIter() {
+		allStatuses = append(allStatuses, s)
+	}
+	fmt.Println("All statuses:", len(allStatuses))
+
+	// early termination example
+	var firstTwo []Status
+	count := 0
+	for s := range StatusIter() {
+		firstTwo = append(firstTwo, s)
+		count++
+		if count >= 2 {
+			break
+		}
+	}
+	fmt.Println("First two statuses:", firstTwo[0], firstTwo[1])
+	// output:
+	// all statuses: 4
+	// first two statuses: active blocked
 }

--- a/_examples/status/status_test.go
+++ b/_examples/status/status_test.go
@@ -141,7 +141,7 @@ func ExampleStatusIter() {
 	for s := range StatusIter() {
 		allStatuses = append(allStatuses, s)
 	}
-	fmt.Println("All statuses:", len(allStatuses))
+	fmt.Println("all statuses:", len(allStatuses))
 
 	// early termination example
 	var firstTwo []Status
@@ -153,7 +153,7 @@ func ExampleStatusIter() {
 			break
 		}
 	}
-	fmt.Println("First two statuses:", firstTwo[0], firstTwo[1])
+	fmt.Println("first two statuses:", firstTwo[0], firstTwo[1])
 	// output:
 	// all statuses: 4
 	// first two statuses: active blocked

--- a/internal/generator/enum.go.tmpl
+++ b/internal/generator/enum.go.tmpl
@@ -126,3 +126,20 @@ func {{.Type | title}}Names() []string {
 	{{end -}}
 	}
 }
+
+// {{.Type | title}}Iter returns a function compatible with Go 1.23's range-over-func syntax.
+// It yields all {{.Type | title}} values in declaration order. Example:
+//
+//	for v := range {{.Type | title}}Iter() {
+//	    // use v
+//	}
+//
+func {{.Type | title}}Iter() func(yield func({{.Type | title}}) bool) {
+	return func(yield func({{.Type | title}}) bool) {
+		for _, v := range {{.Type | title}}Values() {
+			if !yield(v) {
+				break
+			}
+		}
+	}
+}

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -188,7 +188,7 @@ func convertLiteralToInt(lit *ast.BasicLit) (int, error) {
 func (g *Generator) Generate() error {
 	values := make([]Value, 0, len(g.values))
 	names := make([]string, 0, len(g.values))
-	// To avoid an undefined behavior for a Getter, we need to check if the values are unique
+	// to avoid an undefined behavior for a Getter, we need to check if the values are unique
 	if g.generateGetter {
 		valuesCounter := make(map[int][]string)
 		// check if multiple names exist for the same value

--- a/internal/generator/testdata/repeat_values.go
+++ b/internal/generator/testdata/repeat_values.go
@@ -4,7 +4,7 @@ type repeatValues uint8
 
 const (
 	repeatValuesFirst  repeatValues = 10
-	repeatValuesSecond repeatValues     // This should repeat the value 10
+	repeatValuesSecond repeatValues // This should repeat the value 10
 	repeatValuesThird  repeatValues = 20
-	repeatValuesFourth repeatValues     // This should repeat the value 20
+	repeatValuesFourth repeatValues // This should repeat the value 20
 )


### PR DESCRIPTION
## Summary
- Added support for Go 1.23's range-over-func iterator pattern
- Enhanced documentation with examples and improved comments
- Migrated to golangci-lint v2 configuration
- Updated GitHub workflow to use golangci-lint-action@v7

## Changes
- Implemented `TypeIter()` function in the code generation template
- Added comprehensive tests for iterator functionality
- Added example usage in tests and documentation
- Updated config for Go 1.24 compatibility