### PR TITLE
ci: harden workflows, upgrade actions, fix caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,19 +6,24 @@ on:
     tags:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
+      - name: checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
       - name: set up go 1.24
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v6
         with:
           go-version: "1.24"
         id: go
-
-      - name: checkout
-        uses: actions/checkout@v3
 
       - name: build and test
         run: |
@@ -33,16 +38,13 @@ jobs:
         run: go test -timeout=60s -race
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.0.2
-          skip-pkg-cache: true
-
-      - name: install goveralls
-        run: |
-          go install github.com/mattn/goveralls@latest
+          version: "v2.11.1"
 
       - name: submit coverage
-        run: $(go env GOPATH)/bin/goveralls -service="github" -coverprofile=$GITHUB_WORKSPACE/profile.cov
+        run: |
+          go install github.com/mattn/goveralls@latest
+          goveralls -service="github" -coverprofile=$GITHUB_WORKSPACE/profile.cov
         env:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Changes
- Reorder checkout before setup-go for proper dependency caching
- Upgrade all GitHub Actions to latest versions (checkout@v6, setup-go@v6, golangci-lint-action@v9)
- Add `permissions: contents: read` for least-privilege security
- Add `persist-credentials: false` to checkout steps
- Fix goveralls pattern (combined install + submit into single step)
- Upgrade golangci-lint-action from v7 to v9 with golangci-lint v2.11.1
- Remove unnecessary `skip-pkg-cache: true` (setup-go@v6 handles caching)

Verified golangci-lint passes with v2.11.1.