### PR TITLE
Raise golangci-lint to 2.12.2, match all refs on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,8 @@ name: build
 
 on:
   push:
-    branches:
-    tags:
+    branches: ["**"]
+    tags: ["**"]
   pull_request:
 
 permissions:
@@ -40,7 +40,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: "v2.11.1"
+          version: "v2.12.2"
 
       - name: submit coverage
         run: |


### PR DESCRIPTION
The pinned linter was two releases behind; the repository is clean under 2.12.2.

The `push` trigger listed `branches` and `tags` with no value. GitHub reads that as match-all, so the behaviour is unchanged, but it is reported as an empty string by actionlint and the explicit form says what is meant.
