### PR TITLE
Use any in generated code, apply go fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: checkout

--- a/_examples/status/job_status_enum.go
+++ b/_examples/status/job_status_enum.go
@@ -4,6 +4,7 @@ package status
 import (
 	"database/sql/driver"
 	"fmt"
+	"strings"
 )
 
 // JobStatus is the exported type for the enum
@@ -74,13 +75,12 @@ var _jobStatusParseMap = map[string]JobStatus{
 	"blocked":  JobStatusBlocked,
 }
 
-// ParseJobStatus converts string to jobStatus enum value
+// ParseJobStatus converts string to jobStatus enum value.
+// Parsing is always case-insensitive.
 func ParseJobStatus(v string) (JobStatus, error) {
-
-	if val, ok := _jobStatusParseMap[v]; ok {
+	if val, ok := _jobStatusParseMap[strings.ToLower(v)]; ok {
 		return val, nil
 	}
-
 	return JobStatus{}, fmt.Errorf("invalid jobStatus: %s", v)
 }
 

--- a/_examples/status/status_enum.go
+++ b/_examples/status/status_enum.go
@@ -4,6 +4,7 @@ package status
 import (
 	"database/sql/driver"
 	"fmt"
+	"strings"
 )
 
 // Status is the exported type for the enum
@@ -74,13 +75,12 @@ var _statusParseMap = map[string]Status{
 	"blocked":  StatusBlocked,
 }
 
-// ParseStatus converts string to status enum value
+// ParseStatus converts string to status enum value.
+// Parsing is always case-insensitive.
 func ParseStatus(v string) (Status, error) {
-
-	if val, ok := _statusParseMap[v]; ok {
+	if val, ok := _statusParseMap[strings.ToLower(v)]; ok {
 		return val, nil
 	}
-
 	return Status{}, fmt.Errorf("invalid status: %s", v)
 }
 

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -478,8 +478,7 @@ func parseAliasComment(comment *ast.CommentGroup) []string {
 	}
 	for _, c := range comment.List {
 		text := strings.TrimSpace(strings.TrimPrefix(c.Text, "//"))
-		if strings.HasPrefix(text, "enum:alias=") {
-			aliasStr := strings.TrimPrefix(text, "enum:alias=")
+		if aliasStr, ok := strings.CutPrefix(text, "enum:alias="); ok {
 			if aliasStr == "" {
 				return nil
 			}

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -63,7 +63,7 @@ func TestGenerator(t *testing.T) {
 		// check required type definition
 		assert.Contains(t, string(content), "type Status struct {")
 		assert.Contains(t, string(content), "name  string")
-		assert.Contains(t, string(content), "value int")
+		assert.Contains(t, string(content), "value uint8")
 
 		// check all required methods are present
 		methods := []string{

--- a/internal/generator/integration_test.go
+++ b/internal/generator/integration_test.go
@@ -688,7 +688,7 @@ func (n NullableEnum) Value() (driver.Value, error) {
 }
 
 // Scan implements sql.Scanner
-func (n *NullableEnum) Scan(value interface{}) error {
+func (n *NullableEnum) Scan(value any) error {
 	if value == nil {
 		n.Valid = false
 		return nil

--- a/internal/generator/testdata/integration/priority_enum.go
+++ b/internal/generator/testdata/integration/priority_enum.go
@@ -4,11 +4,10 @@ package integration
 import (
 	"database/sql/driver"
 	"fmt"
-	"strings"
-
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/bsontype"
 	"gopkg.in/yaml.v3"
+	"strings"
 )
 
 // Priority is the exported type for the enum
@@ -117,13 +116,12 @@ var _priorityParseMap = map[string]Priority{
 	"critical": PriorityCritical,
 }
 
-// ParsePriority converts string to priority enum value
+// ParsePriority converts string to priority enum value.
+// Parsing is always case-insensitive.
 func ParsePriority(v string) (Priority, error) {
-
 	if val, ok := _priorityParseMap[strings.ToLower(v)]; ok {
 		return val, nil
 	}
-
 	return Priority{}, fmt.Errorf("invalid priority: %s", v)
 }
 

--- a/internal/generator/testdata/integration/status_enum.go
+++ b/internal/generator/testdata/integration/status_enum.go
@@ -4,11 +4,10 @@ package integration
 import (
 	"database/sql/driver"
 	"fmt"
-	"strings"
-
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/bsontype"
 	"gopkg.in/yaml.v3"
+	"strings"
 )
 
 // Status is the exported type for the enum


### PR DESCRIPTION
Previously the generated `Scan` method took an `interface{}` parameter while the rest of the template already used `any`. After this change the template emits `any` throughout. `go fix` makes the same replacement in a test helper and rewrites a `HasPrefix`/`TrimPrefix` pair into `strings.CutPrefix`.

The committed generated files are regenerated. That also brings the examples up to date with the case-insensitive parsing added to the template earlier, and leaves the integration test data byte for byte what the generator produces, so running the tests no longer leaves a modified file behind.

One test asserted that the generated code contains `value int`, which only ever matched because of the `interface{}` in `Scan`. The enum in that test is `uint8` based, so the assertion now names the field type it actually has.

What changes for existing users: generated code no longer compiles in a module that declares a language version below Go 1.18, and a consumer package that declares its own `any` identifier shadows the predeclared one the generated type assertions rely on. The template already emitted `any` in the YAML block, so the second case was reachable before this change.
